### PR TITLE
Add run on repl.it badge to README

### DIFF
--- a/.replit
+++ b/.replit
@@ -1,0 +1,2 @@
+language = "cpp"
+run = ""

--- a/README.md
+++ b/README.md
@@ -6,3 +6,4 @@
 
 #### Avatar:
 <img src = "https://user-images.githubusercontent.com/60235679/73091037-2f269000-3e9f-11ea-826b-978a08248895.jpg" width = "180" height="200"/>
+[![Run on Repl.it](https://repl.it/badge/github/Kyrie-Ma/3013-ALG-Ma)](https://repl.it/github/Kyrie-Ma/3013-ALG-Ma)


### PR DESCRIPTION
This pull request configures this repository to be run on Repl.it.      It adds a `.replit` configuration file and a Repl.it badge to the `README`.
     You can read more about running repos on Repl.it [here](https://docs.repl.it/repls/dot-replit), or view the Repl [here](https://repl.it/@KyrieMa/3013-ALG-Ma-7).